### PR TITLE
Inspect geometry blobs in a compact preview grid

### DIFF
--- a/apps/web/src/parser/asset-gallery.ts
+++ b/apps/web/src/parser/asset-gallery.ts
@@ -1,0 +1,5 @@
+/** Shared layout for embedded image and geometry assets. */
+export const assetGridClassName =
+  "grid grid-cols-[repeat(auto-fill,minmax(min(100%,10rem),1fr))] gap-4"
+
+export const assetCardClassName = "min-w-0 rounded-md border bg-card p-3"

--- a/apps/web/src/parser/blob-content.tsx
+++ b/apps/web/src/parser/blob-content.tsx
@@ -1,0 +1,130 @@
+import { useMemo } from "react"
+import { BlobInspector } from "fig-renderer"
+import type { GUID } from "fig-kiwi/schema-defs"
+import type { BlobReference } from "./blob-references"
+import { HexView } from "./hex-view"
+import { ImageLightbox } from "./image-lightbox"
+
+export function BlobContent({
+  bytes,
+  index,
+  references = [],
+  onSelect,
+}: {
+  bytes: Uint8Array
+  index: number
+  references?: BlobReference[]
+  onSelect: (guid: GUID, blob: number, path: string) => void
+}) {
+  const network = references.some((r) =>
+    /(?:^|\.)vectorNetworkBlob$/.test(r.path)
+  )
+  const path = references.some((r) => /(?:^|\.)commandsBlob$/.test(r.path))
+  return (
+    <BlobInspector
+      bytes={bytes}
+      renderBytes={(data) => <HexView bytes={data} />}
+      renderDetails={(content, onClose) => (
+        <ImageLightbox
+          title={`Blob ${index} details`}
+          closeLabel="Close blob"
+          onClose={onClose}
+        >
+          <div className="max-h-[calc(100dvh-4rem)] w-[min(64rem,calc(100vw-4rem))] overflow-auto p-6">
+            {content}
+          </div>
+        </ImageLightbox>
+      )}
+      kind={network === path ? "unknown" : network ? "vector-network" : "path"}
+      glyph={
+        path &&
+        references.every((r) =>
+          /(?:^|\.)glyphs\[\d+\]\.commandsBlob$/.test(r.path)
+        )
+      }
+      heading={
+        <>
+          <span title={`${bytes.length.toLocaleString()} bytes`}>
+            {bytes.length < 1024
+              ? `${bytes.length} B`
+              : `${(bytes.length / 1024).toFixed(1)} KB`}
+          </span>
+        </>
+      }
+      references={(expanded) => (
+        <BlobUsage
+          references={references}
+          expanded={expanded}
+          onSelect={(r) => r.guid && onSelect(r.guid, index, r.path)}
+        />
+      )}
+    />
+  )
+}
+
+function BlobUsage({
+  references,
+  expanded,
+  onSelect,
+}: {
+  references: BlobReference[]
+  expanded: boolean
+  onSelect: (reference: BlobReference) => void
+}) {
+  const groups = useMemo(() => {
+    const nodes = new Map<number, BlobReference[]>()
+    for (const r of references) {
+      const group = nodes.get(r.nodeIndex)
+      if (group) group.push(r)
+      else nodes.set(r.nodeIndex, [r])
+    }
+    return [...nodes.values()]
+  }, [references])
+  if (!groups.length) return null
+  const visible = expanded ? groups : groups.slice(0, 3)
+  return (
+    <ul className="flex flex-wrap gap-x-2 text-sm leading-5">
+      {visible.map((group) => {
+        const first = group[0]
+        const label = first.guid
+          ? `${first.guid.sessionID}:${first.guid.localID}`
+          : `nodeChanges[${first.nodeIndex}]`
+        return (
+          <li key={first.nodeIndex} className="min-w-0">
+            {first.guid ? (
+              <button
+                className="inline-flex max-w-full items-center gap-1 text-left text-blue-700 hover:underline"
+                title={`${first.nodeName} (${label})\n${group.map((r) => r.path).join("\n")}`}
+                onClick={() => onSelect(first)}
+              >
+                <span className="truncate">{label}</span>
+                <svg
+                  aria-hidden="true"
+                  className="h-3 w-3 shrink-0"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="M7 17 17 7M7 7h10v10" />
+                </svg>
+              </button>
+            ) : (
+              label
+            )}
+          </li>
+        )
+      })}
+      {!expanded && groups.length > visible.length && (
+        <li
+          className="text-muted-foreground"
+          title="More references in details"
+        >
+          +{groups.length - visible.length}
+        </li>
+      )}
+    </ul>
+  )
+}

--- a/apps/web/src/parser/file-viewer.tsx
+++ b/apps/web/src/parser/file-viewer.tsx
@@ -20,7 +20,8 @@ import { GUID, NodeChange } from "fig-kiwi/schema-defs"
 import { cn } from "@/lib/utils"
 import { NodeTree } from "./node-tree"
 import { CodeView } from "./code-view"
-import { hex, replacerForHex } from "./hex"
+import { replacerForHex } from "./hex"
+import { HexView } from "./hex-view"
 import { Button } from "@/components/ui/button"
 import { compileSchema } from "kiwi-schema"
 import { ImagePreview } from "./image-lightbox"
@@ -31,6 +32,8 @@ import { FigmaRenderer } from "fig-renderer"
 import { SiblingPosition } from "./sibling-position"
 import { SplitView } from "@/components/split-view"
 import { useViewerNavigation, type NavSelection } from "./use-viewer-navigation"
+import { BlobContent } from "./blob-content"
+import { assetCardClassName, assetGridClassName } from "./asset-gallery"
 
 type FileContents = ParsedFigmaBlob | ParsedFigmaHTML
 
@@ -82,7 +85,11 @@ export function FigmaFile({ data }: { data: FileContents }) {
             imageCount={assets.length}
             hasThumbnail={"preview" in data && !!data.preview}
             selected={
-              navSelection.type === "layer" ? navSelection.guid : sceneSelection
+              navSelection.type === "layer"
+                ? navSelection.guid
+                : navSelection.type === "preview"
+                  ? sceneSelection
+                  : undefined
             }
             onSelect={(guid) => {
               setSceneSelection(guid)
@@ -223,58 +230,20 @@ function Blobs({
     [message, schema]
   )
   return (
-    <div className="flex flex-col space-y-4">
+    <div className={assetGridClassName}>
       {message.blobs?.map((b, i) => (
-        <Card key={i}>
-          <CardHeader>
-            <h2>
-              Blob {i}{" "}
-              <span className="font-medium">({b.bytes.length} bytes)</span>
-            </h2>
-            {references.has(i) ? (
-              <div className="space-y-1 text-sm">
-                <p className="text-muted-foreground">Referenced by</p>
-                <ul className="space-y-1">
-                  {references.get(i)!.map((reference) => (
-                    <li key={`${reference.nodeIndex}:${reference.path}`}>
-                      {reference.guid ? (
-                        <button
-                          type="button"
-                          onClick={() =>
-                            onSelect(reference.guid!, i, reference.path)
-                          }
-                          className="flex max-w-full flex-wrap items-baseline gap-x-2 rounded-sm text-left underline underline-offset-2 hover:text-muted-foreground focus-visible:outline-2 focus-visible:outline-offset-2"
-                        >
-                          <span>
-                            {reference.nodeName} ({formatGUID(reference.guid)})
-                          </span>
-                          <code className="break-all text-xs">
-                            {reference.path}
-                          </code>
-                        </button>
-                      ) : (
-                        <span className="break-all text-muted-foreground">
-                          {reference.nodeName} · nodeChanges[
-                          {reference.nodeIndex}].
-                          {reference.path}
-                        </span>
-                      )}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            ) : (
-              <p className="text-sm text-muted-foreground">
-                No node references found.
-              </p>
-            )}
-          </CardHeader>
-          <CardContent>
-            <span className="font-mono font-xs text-gray-700 dark:text-gray-400">
-              {hex(b.bytes, " ")}
-            </span>
-          </CardContent>
-        </Card>
+        <section
+          key={i}
+          aria-label={`Blob ${i}`}
+          className={assetCardClassName}
+        >
+          <BlobContent
+            bytes={b.bytes}
+            index={i}
+            references={references.get(i)}
+            onSelect={onSelect}
+          />
+        </section>
       ))}
     </div>
   )
@@ -401,8 +370,12 @@ function Sidebar({
           <SidebarItem
             onClick={() => setNavSelection({ type: "blobs" })}
             selected={navSelection.type === "blobs"}
+            className="flex items-center justify-between gap-2"
           >
-            Blobs
+            <span>Blobs</span>
+            <span className="min-w-6 rounded-full bg-background/70 px-2 py-0.5 text-center text-xs tabular-nums text-muted-foreground">
+              {message.blobs?.length ?? 0}
+            </span>
           </SidebarItem>
           {imageCount > 0 && (
             <SidebarItem
@@ -595,9 +568,7 @@ function NodeContent({
         {data && (
           <>
             <h3>As kiwi ({data.length} bytes)</h3>
-            <p className="font-xs font-mono text-gray-700 dark:text-gray-400">
-              {hex(data, " ")}
-            </p>
+            <HexView bytes={data} />
           </>
         )}
       </CardContent>

--- a/apps/web/src/parser/hex-view.tsx
+++ b/apps/web/src/parser/hex-view.tsx
@@ -1,0 +1,51 @@
+import { useMemo, useState } from "react"
+import { hex } from "./hex"
+import { Button } from "@/components/ui/button"
+
+export function HexView({ bytes }: { bytes: Uint8Array }) {
+  const [page, setPage] = useState(0)
+  const pageSize = 512
+  const currentPage = Math.min(
+    page,
+    Math.max(0, Math.ceil(bytes.length / pageSize) - 1)
+  )
+  const start = currentPage * pageSize
+  const end = Math.min(start + pageSize, bytes.length)
+  const text = useMemo(
+    () => hex(bytes.subarray(start, end), " "),
+    [bytes, start, end]
+  )
+  return (
+    <div>
+      <p className="break-words font-mono text-xs leading-relaxed text-gray-700 dark:text-gray-400">
+        {text || "Empty"}
+      </p>
+      {bytes.length > pageSize && (
+        <nav
+          aria-label="Hex bytes pages"
+          className="mt-3 flex items-center gap-2 text-sm text-muted-foreground"
+        >
+          <span className="mr-auto">
+            {start + 1}–{end} of {bytes.length.toLocaleString()} bytes
+          </span>
+          <Button
+            size="sm"
+            variant="ghost"
+            disabled={!currentPage}
+            onClick={() => setPage(currentPage - 1)}
+          >
+            Previous
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            disabled={end === bytes.length}
+            onClick={() => setPage(currentPage + 1)}
+          >
+            Next
+          </Button>
+        </nav>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/parser/image-lightbox.tsx
+++ b/apps/web/src/parser/image-lightbox.tsx
@@ -3,10 +3,12 @@ import { createPortal } from "react-dom"
 
 export function ImageLightbox({
   title,
+  closeLabel = "Close image",
   onClose,
   children,
 }: {
   title: string
+  closeLabel?: string
   onClose: () => void
   children: ReactNode
 }) {
@@ -50,7 +52,7 @@ export function ImageLightbox({
           <button
             type="button"
             onClick={onClose}
-            aria-label="Close image"
+            aria-label={closeLabel}
             className="absolute -right-3 -top-3 flex h-8 w-8 items-center justify-center rounded-full bg-card text-card-foreground shadow-md hover:bg-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
           >
             <svg

--- a/packages/fig-renderer/README.md
+++ b/packages/fig-renderer/README.md
@@ -35,6 +35,22 @@ binary geometry decoders. It imports neither React nor CSS and works in non-brow
 tests. `buildNodeTree` is shared with the web app so sibling ordering and parent links
 remain consistent.
 
+`BlobInspector` renders a standalone geometry preview with decoded-record
+and raw-byte views. Pass `bytes`, `kind` (`"path"`, `"vector-network"`, or
+`"unknown"`) based on the field referencing the blob, and `glyph` for Y-up glyph
+outlines. Supply `renderDetails(content, onClose)` to open the records in the host’s
+lightbox when the preview is clicked, and `renderBytes` to reuse the host’s hex view.
+The `references` slot can be a function of the expanded state so the card shows a
+capped list and the lightbox shows every reference. Network previews can show
+vertices and Bézier handles. Decoding is deferred
+until a card approaches the viewport; record tables are paginated and created only
+when expanded. Unknown or malformed data retains its raw-byte view.
+
+`inspectCommands` and `inspectVectorNetwork` from `fig-renderer/core` expose the same
+decoders' records, including byte offsets and uninterpreted style/flag words. The
+inspector rounds displayed coordinates to seven significant digits for readability;
+raw bytes preserve the original float32 values.
+
 ## Geometry and text
 
 Saved node transforms and sizes are authoritative; the renderer does not run auto

--- a/packages/fig-renderer/package.json
+++ b/packages/fig-renderer/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "typecheck": "tsc --noEmit",
     "test": "bun test ./tests",
-    "build": "tsc -p tsconfig.build.json && cp src/renderer.css dist/renderer.css"
+    "build": "tsc -p tsconfig.build.json && cp src/*.css dist/"
   },
   "dependencies": {
     "fig-kiwi": "workspace:*"

--- a/packages/fig-renderer/src/blob-inspector.css
+++ b/packages/fig-renderer/src/blob-inspector.css
@@ -1,0 +1,204 @@
+.fig-blob {
+  min-width: 0;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.fig-blob__overview {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  align-items: start;
+  gap: 8px;
+}
+.fig-blob__info {
+  min-width: 0;
+  padding: 0;
+}
+.fig-blob__references {
+  height: 40px;
+  overflow: auto;
+  margin-bottom: 4px;
+}
+.fig-blob__heading {
+  display: flex;
+  align-items: baseline;
+  white-space: nowrap;
+  overflow: hidden;
+  gap: 4px 8px;
+}
+.fig-blob__heading span {
+  color: #6b7280;
+  font-size: 14px;
+}
+.fig-blob__geometry {
+  position: relative;
+  min-width: 0;
+  border-radius: 6px;
+  background: color-mix(in oklab, var(--muted, #f1f5f9) 40%, transparent);
+  overflow: hidden;
+}
+.fig-blob__geometry svg {
+  display: block;
+  width: 100%;
+  height: auto;
+  aspect-ratio: 1;
+  padding: 32px 8px 8px;
+  box-sizing: border-box;
+}
+.fig-blob__type {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  color: #6b7280;
+  font-size: 14px;
+  pointer-events: none;
+}
+.fig-blob__placeholder {
+  display: grid;
+  place-items: center;
+  min-height: 112px;
+  aspect-ratio: 1;
+  color: #9ca3af;
+}
+.fig-blob > .fig-blob__placeholder {
+  padding-bottom: 73px;
+  box-sizing: content-box;
+}
+.fig-blob__preview-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 8px;
+  padding: 36px 8px 8px;
+  font-size: 14px;
+  color: #6b7280;
+}
+.fig-blob__preview-controls label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+}
+.fig-blob__detail-panel {
+  margin-top: 16px;
+}
+.fig-blob__views {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 16px;
+}
+.fig-blob__views button {
+  padding: 4px 10px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: #6b7280;
+  font: inherit;
+  cursor: pointer;
+}
+.fig-blob__views button[aria-pressed="true"] {
+  background: #e5e7eb;
+  color: #111827;
+}
+.fig-blob--expanded .fig-blob__overview {
+  grid-template-columns: minmax(180px, 40%) minmax(0, 1fr);
+}
+.fig-blob--expanded .fig-blob__geometry svg {
+  height: 220px;
+  aspect-ratio: auto;
+}
+.fig-blob--expanded .fig-blob__references {
+  height: auto;
+  max-height: 160px;
+}
+.fig-blob button:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}
+.fig-blob__note {
+  margin: 0 0 12px;
+  color: #6b7280;
+}
+.fig-blob__pager {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+}
+@media (max-width: 600px) {
+  .fig-blob--expanded .fig-blob__overview {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+.fig-blob__records {
+  margin: 16px 0;
+}
+.fig-blob__table-scroll {
+  max-height: 400px;
+  overflow: auto;
+}
+.fig-blob__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-variant-numeric: tabular-nums;
+  text-align: left;
+}
+.fig-blob__table caption {
+  padding: 0 0 8px;
+  font-weight: 600;
+  text-align: left;
+}
+.fig-blob__table th,
+.fig-blob__table td {
+  padding: 6px 10px;
+  border-bottom: 1px solid #e5e7eb;
+  white-space: nowrap;
+  vertical-align: top;
+}
+.fig-blob__table th {
+  font-size: 14px;
+  font-weight: 500;
+  color: #6b7280;
+}
+.fig-blob__table td {
+  font-family: ui-monospace, SFMono-Regular, monospace;
+  font-size: 12px;
+}
+.fig-blob__indices {
+  display: block;
+  min-width: 220px;
+  max-width: 600px;
+  white-space: normal;
+}
+.fig-blob__pager {
+  margin-top: 8px;
+}
+.fig-blob__pager span {
+  margin-right: auto;
+  color: #6b7280;
+}
+.fig-blob__pager button {
+  padding: 4px 8px;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+.fig-blob__pager button:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.fig-blob__open {
+  display: block;
+  width: 100%;
+  padding: 0;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  cursor: zoom-in;
+  font: inherit;
+}
+.fig-blob__open:hover {
+  opacity: 0.85;
+}

--- a/packages/fig-renderer/src/blob-inspector.tsx
+++ b/packages/fig-renderer/src/blob-inspector.tsx
@@ -1,0 +1,574 @@
+import {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react"
+import {
+  inspectCommands,
+  inspectVectorNetwork,
+  type DecodedVectorNetwork,
+  type PathCommand,
+} from "./geometry"
+import "./blob-inspector.css"
+
+export interface BlobInspectorProps {
+  bytes: Uint8Array
+  /** Choose from the field referencing the blob; arbitrary bytes are not sniffed. */
+  kind: "path" | "vector-network" | "unknown"
+  /** Glyph outlines use em coordinates with Y pointing up. */
+  glyph?: boolean
+  heading?: ReactNode
+  references?: ReactNode | ((expanded: boolean) => ReactNode)
+  /** Host-provided binary view keeps byte formatting consistent with the app. */
+  renderBytes?: (bytes: Uint8Array) => ReactNode
+  /** Host-provided lightbox keeps focus and dismissal behavior consistent. */
+  renderDetails: (content: ReactNode, onClose: () => void) => ReactNode
+}
+
+export function BlobInspector(props: BlobInspectorProps) {
+  const container = useRef<HTMLDivElement>(null)
+  const [visible, setVisible] = useState(false)
+  useEffect(() => {
+    const element = container.current
+    if (!element) return
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setVisible(true)
+          observer.disconnect()
+        }
+      },
+      { rootMargin: "300px" }
+    )
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [])
+  return (
+    <div ref={container} className="fig-blob">
+      {visible ? (
+        <DecodedBlob {...props} />
+      ) : (
+        <div className="fig-blob__placeholder">Blob preview</div>
+      )}
+    </div>
+  )
+}
+
+function DecodedBlob({
+  bytes,
+  kind,
+  glyph = false,
+  heading,
+  references,
+  renderBytes,
+  renderDetails,
+}: BlobInspectorProps) {
+  const commands = useMemo(
+    () => (kind === "path" ? inspectCommands(bytes) : undefined),
+    [bytes, kind]
+  )
+  const network = useMemo(
+    () => (kind === "vector-network" ? inspectVectorNetwork(bytes) : undefined),
+    [bytes, kind]
+  )
+  const [expanded, setExpanded] = useState(false)
+  const [view, setView] = useState<"records" | "bytes">("records")
+  const decoded = !!(commands || network)
+  const label = network
+    ? "Network"
+    : commands
+      ? glyph
+        ? "Glyph"
+        : "Path"
+      : "Binary"
+  const overview = (showDetails: boolean) => (
+    <div className="fig-blob__overview">
+      {showDetails ? (
+        decoded ? (
+          <GeometryPreview
+            path={commands?.path}
+            network={network}
+            glyph={glyph}
+            expanded={showDetails}
+          />
+        ) : (
+          <div className="fig-blob__placeholder">Binary</div>
+        )
+      ) : (
+        <button
+          className="fig-blob__open"
+          aria-label={`Inspect ${label.toLowerCase()} blob`}
+          aria-haspopup="dialog"
+          onClick={() => setExpanded(true)}
+        >
+          {decoded ? (
+            <GeometryPreview
+              path={commands?.path}
+              network={network}
+              glyph={glyph}
+              expanded={showDetails}
+            />
+          ) : (
+            <div className="fig-blob__placeholder">Binary</div>
+          )}
+        </button>
+      )}
+      <div className="fig-blob__info">
+        <div className="fig-blob__references">
+          {typeof references === "function"
+            ? references(showDetails)
+            : references}
+        </div>
+        <div className="fig-blob__heading">{heading}</div>
+      </div>
+    </div>
+  )
+  return (
+    <>
+      {overview(false)}
+      {expanded &&
+        renderDetails(
+          <div className="fig-blob fig-blob--expanded">
+            {overview(true)}
+            <div className="fig-blob__detail-panel">
+              <div
+                className="fig-blob__views"
+                role="group"
+                aria-label="Blob detail view"
+              >
+                {decoded && (
+                  <button
+                    aria-pressed={view === "records"}
+                    onClick={() => setView("records")}
+                  >
+                    Records
+                  </button>
+                )}
+                {renderBytes && (
+                  <button
+                    aria-pressed={view === "bytes" || !decoded}
+                    onClick={() => setView("bytes")}
+                  >
+                    Bytes
+                  </button>
+                )}
+              </div>
+              {!decoded && (
+                <p className="fig-blob__note">
+                  {kind === "unknown"
+                    ? "No supported geometry format identified."
+                    : "The blob could not be decoded completely. It may be truncated or use an unsupported format."}
+                </p>
+              )}
+              {view === "bytes" || !decoded ? (
+                renderBytes?.(bytes)
+              ) : (
+                <>
+                  <p className="fig-blob__note">
+                    {commands
+                      ? `One-byte opcodes, then little-endian float32 coordinates.${glyph ? " Glyph coordinates use em units with Y up." : ""}`
+                      : "Little-endian uint32 integers and float32 coordinates. Offsets are hexadecimal byte positions."}
+                  </p>
+                  {commands && (
+                    <RecordTable
+                      label={`${commands.commands.length} commands`}
+                      records={commands.commands}
+                      columns={[
+                        "#",
+                        "Offset",
+                        "Bytes",
+                        "Command",
+                        "Coordinates",
+                      ]}
+                      render={(command, index) => [
+                        index,
+                        offsetLabel(command.offset),
+                        command.byteLength,
+                        `${command.opcode} · ${verbNames[command.verb]}`,
+                        commandCoordinates(command),
+                      ]}
+                    />
+                  )}
+                  {commands?.commands[0]?.verb === "Z" && (
+                    <p className="fig-blob__note">
+                      Leading Close commands have no active contour and do not
+                      draw anything.
+                    </p>
+                  )}
+                  {network && <NetworkRecords network={network} />}
+                </>
+              )}
+            </div>
+          </div>,
+          () => setExpanded(false)
+        )}
+    </>
+  )
+}
+
+const verbNames = {
+  M: "Move",
+  L: "Line",
+  Q: "Quadratic",
+  C: "Cubic",
+  Z: "Close",
+}
+const number = (value: number) => String(Number(value.toPrecision(7)))
+const pair = (x: number, y: number) => `(${number(x)}, ${number(y)})`
+const offsetLabel = (offset: number) =>
+  `0x${offset.toString(16).padStart(6, "0")}`
+
+function commandCoordinates({ verb, values: v }: PathCommand) {
+  if (verb === "Z") return "—"
+  if (verb === "Q")
+    return `control ${pair(v[0], v[1])} → end ${pair(v[2], v[3])}`
+  if (verb === "C")
+    return `c1 ${pair(v[0], v[1])} · c2 ${pair(v[2], v[3])} → end ${pair(v[4], v[5])}`
+  return pair(v[0], v[1])
+}
+
+function GeometryPreview({
+  path,
+  network,
+  glyph,
+  expanded,
+}: {
+  path?: string
+  network?: DecodedVectorNetwork
+  glyph: boolean
+  expanded: boolean
+}) {
+  const drawing = useRef<SVGGElement>(null)
+  const [bounds, setBounds] = useState({ x: 0, y: 0, width: 100, height: 100 })
+  const [vertices, setVertices] = useState(
+    !!network && network.segments.length === 0
+  )
+  const [handles, setHandles] = useState(false)
+  useLayoutEffect(() => {
+    const svg = drawing.current?.ownerSVGElement
+    if (!svg) return
+    const measure = () => {
+      // A native dialog is initially hidden; measure again when it opens.
+      if (!svg.getBoundingClientRect().width) return
+      const box = drawing.current?.getBBox()
+      if (!box || ![box.x, box.y, box.width, box.height].every(Number.isFinite))
+        return
+      const span = Math.max(box.width, box.height, 0.001)
+      const padding = span * 0.08
+      setBounds({
+        x: box.x - padding,
+        y: box.y - padding,
+        width: box.width + padding * 2,
+        height: box.height + padding * 2,
+      })
+    }
+    const observer = new ResizeObserver(measure)
+    observer.observe(svg)
+    measure()
+    return () => observer.disconnect()
+  }, [path, network, glyph, handles])
+  const radius = Math.max(bounds.width, bounds.height) / 160
+  const hasGeometry = !!(path || network?.stroke || network?.vertices.length)
+  return (
+    <div className="fig-blob__geometry">
+      <span className="fig-blob__type">
+        {network ? "Network" : glyph ? "Glyph" : "Path"}
+      </span>
+      {expanded && network && (
+        <div className="fig-blob__preview-controls">
+          {network && (
+            <>
+              <label>
+                <input
+                  type="checkbox"
+                  checked={vertices}
+                  onChange={(e) => setVertices(e.target.checked)}
+                />{" "}
+                Vertices
+              </label>
+              <label>
+                <input
+                  type="checkbox"
+                  checked={handles}
+                  onChange={(e) => setHandles(e.target.checked)}
+                />{" "}
+                Curve handles
+              </label>
+            </>
+          )}
+        </div>
+      )}
+      {hasGeometry ? (
+        <svg
+          viewBox={`${bounds.x} ${bounds.y} ${bounds.width} ${bounds.height}`}
+          role="img"
+          aria-label={
+            network
+              ? "Decoded vector network"
+              : glyph
+                ? "Decoded glyph outline"
+                : "Decoded path geometry"
+          }
+        >
+          <g ref={drawing}>
+            <g transform={glyph ? "scale(1 -1)" : undefined}>
+              <path
+                d={
+                  network ? (network.regions.length ? network.fill : "") : path
+                }
+                fill="#dbeafe"
+                fillRule={network ? "evenodd" : "nonzero"}
+              />
+              <path
+                d={network?.stroke ?? path}
+                fill="none"
+                stroke="#2563eb"
+                strokeWidth={1}
+                vectorEffect="non-scaling-stroke"
+              />
+              {network &&
+                !network.stroke &&
+                network.vertices.map((v, i) => (
+                  <path key={i} d={`M${v.x} ${v.y}h0.001`} stroke="#2563eb" />
+                ))}
+              {handles &&
+                network?.segments.map((s, i) => {
+                  const a = network.vertices[s.start],
+                    b = network.vertices[s.end]
+                  return (
+                    <g key={i} stroke="#a855f7" fill="#a855f7" strokeWidth={1}>
+                      <path
+                        d={`M${a.x} ${a.y}l${s.tx} ${s.ty} M${b.x} ${b.y}l${s.ex} ${s.ey}`}
+                        vectorEffect="non-scaling-stroke"
+                      />
+                    </g>
+                  )
+                })}
+            </g>
+          </g>
+          <g transform={glyph ? "scale(1 -1)" : undefined}>
+            {vertices &&
+              network?.vertices.map((v, i) => (
+                <circle
+                  key={i}
+                  cx={v.x}
+                  cy={v.y}
+                  r={radius}
+                  fill="white"
+                  stroke="#2563eb"
+                  strokeWidth={1}
+                  vectorEffect="non-scaling-stroke"
+                >
+                  <title>{`Vertex ${i} ${pair(v.x, v.y)}`}</title>
+                </circle>
+              ))}
+            {handles &&
+              network?.segments.map((s, i) => {
+                const a = network.vertices[s.start],
+                  b = network.vertices[s.end]
+                return (
+                  <g key={i} fill="#a855f7">
+                    {(s.tx !== 0 || s.ty !== 0) && (
+                      <circle
+                        cx={a.x + s.tx}
+                        cy={a.y + s.ty}
+                        r={radius * 0.65}
+                      />
+                    )}
+                    {(s.ex !== 0 || s.ey !== 0) && (
+                      <circle
+                        cx={b.x + s.ex}
+                        cy={b.y + s.ey}
+                        r={radius * 0.65}
+                      />
+                    )}
+                  </g>
+                )
+              })}
+          </g>
+        </svg>
+      ) : (
+        <div className="fig-blob__placeholder">No drawable geometry</div>
+      )}
+    </div>
+  )
+}
+
+function NetworkRecords({ network: n }: { network: DecodedVectorNetwork }) {
+  return (
+    <>
+      <table className="fig-blob__table">
+        <caption>Header · 12 bytes</caption>
+        <thead>
+          <tr>
+            <th>Offset</th>
+            <th>Field</th>
+            <th>Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          {[
+            [0, "Vertex count", n.vertices.length],
+            [4, "Segment count", n.segments.length],
+            [8, "Region count", n.regions.length],
+          ].map(([offset, label, count]) => (
+            <tr key={offset}>
+              <td>{offsetLabel(offset as number)}</td>
+              <td>{label}</td>
+              <td>{count}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <RecordTable
+        label="Vertices · 12 bytes each"
+        records={n.vertices}
+        columns={["Vertex", "Offset", "Style (raw)", "X", "Y"]}
+        render={(v, i) => [
+          i,
+          offsetLabel(v.offset),
+          v.style,
+          number(v.x),
+          number(v.y),
+        ]}
+      />
+      <RecordTable
+        label="Segments · 28 bytes each"
+        records={n.segments}
+        columns={[
+          "Segment",
+          "Offset",
+          "Style (raw)",
+          "Start → End",
+          "Start tangent",
+          "End tangent",
+        ]}
+        render={(s, i) => [
+          i,
+          offsetLabel(s.offset),
+          s.style,
+          `${s.start} → ${s.end}`,
+          pair(s.tx, s.ty),
+          pair(s.ex, s.ey),
+        ]}
+      />
+      <p className="fig-blob__note">
+        Tangents are offsets from their endpoint vertices. Style words and
+        region flags are preserved raw; their full meaning is not decoded. The
+        preview uses even-odd filling and does not apply corner rounding.
+      </p>
+      <RecordTable
+        label="Regions"
+        records={n.regions}
+        columns={["Region", "Offset", "Flags (raw)", "Loop count"]}
+        render={(r, i) => [
+          i,
+          offsetLabel(r.offset),
+          offsetLabel(r.flags),
+          r.loops.length,
+        ]}
+      />
+      {n.regions.length > 0 && (
+        <RecordTable
+          label="Region loops"
+          records={n.regions.flatMap((r, region) =>
+            r.loops.map((loop, index) => ({ ...loop, region, index }))
+          )}
+          columns={["Region / Loop", "Offset", "Segments in stored order"]}
+          render={(loop) => [
+            `${loop.region} / ${loop.index}`,
+            offsetLabel(loop.offset),
+            <span className="fig-blob__indices">
+              {loop.segments.join(", ") || "Empty loop"}
+            </span>,
+          ]}
+        />
+      )}
+    </>
+  )
+}
+
+function RecordTable<T>({
+  label,
+  columns,
+  records,
+  render,
+}: {
+  label: string
+  columns: string[]
+  records: readonly T[]
+  render: (record: T, index: number) => ReactNode[]
+}) {
+  const [page, setPage] = useState(0)
+  const size = 50
+  return (
+    <div className="fig-blob__records">
+      <div className="fig-blob__table-scroll">
+        <table className="fig-blob__table">
+          <caption>{label}</caption>
+          <thead>
+            <tr>
+              {columns.map((c) => (
+                <th key={c}>{c}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {records.slice(page * size, (page + 1) * size).map((r, i) => (
+              <tr key={page * size + i}>
+                {render(r, page * size + i).map((value, c) => (
+                  <td key={c}>{value}</td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {!records.length && <p className="fig-blob__note">None</p>}
+      </div>
+      {records.length > size && (
+        <Pager
+          page={page}
+          size={size}
+          count={records.length}
+          onChange={setPage}
+          label={label}
+        />
+      )}
+    </div>
+  )
+}
+
+function Pager({
+  page,
+  size,
+  count,
+  onChange,
+  label,
+}: {
+  page: number
+  size: number
+  count: number
+  onChange: (page: number) => void
+  label: string
+}) {
+  return (
+    <nav className="fig-blob__pager" aria-label={`${label} pages`}>
+      <span>
+        {page * size + 1}–{Math.min((page + 1) * size, count)} of{" "}
+        {count.toLocaleString()}
+      </span>
+      <button disabled={page === 0} onClick={() => onChange(page - 1)}>
+        Previous
+      </button>
+      <button
+        disabled={(page + 1) * size >= count}
+        onClick={() => onChange(page + 1)}
+      >
+        Next
+      </button>
+    </nav>
+  )
+}

--- a/packages/fig-renderer/src/core.ts
+++ b/packages/fig-renderer/src/core.ts
@@ -3,3 +3,12 @@ export type { TreeNode } from "./hierarchy"
 export { buildScene, fitCamera, zoomCamera } from "./scene-data"
 export type { Scene, SceneItem, SceneNode, Bounds, Camera } from "./scene-data"
 export { decodeCommands, decodeVectorNetwork } from "./geometry"
+export { inspectCommands, inspectVectorNetwork } from "./geometry"
+export type {
+  DecodedCommands,
+  PathCommand,
+  DecodedVectorNetwork,
+  NetworkVertex,
+  NetworkSegment,
+  NetworkRegion,
+} from "./geometry"

--- a/packages/fig-renderer/src/geometry.ts
+++ b/packages/fig-renderer/src/geometry.ts
@@ -4,14 +4,31 @@ import type { Matrix, NodeChange, Vector } from "fig-kiwi/schema-defs"
  * Glyphs use the same format, in em units with Y pointing up.
  * Fail the entire path on unknown/truncated data instead of drawing corruption.
  */
-export function decodeCommands(bytes: Uint8Array): string | undefined {
+export interface PathCommand {
+  offset: number
+  byteLength: number
+  opcode: number
+  verb: "Z" | "M" | "L" | "Q" | "C"
+  values: number[]
+}
+
+export interface DecodedCommands {
+  path: string
+  commands: PathCommand[]
+}
+
+export function inspectCommands(
+  bytes: Uint8Array
+): DecodedCommands | undefined {
   const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
   const commands: string[] = []
-  const names = ["Z", "M", "L", "Q", "C"]
+  const records: PathCommand[] = []
+  const names = ["Z", "M", "L", "Q", "C"] as const
   const counts = [0, 2, 2, 4, 6]
   let offset = 0
   let started = false
   while (offset < bytes.length) {
+    const start = offset
     const opcode = bytes[offset++]
     const count = counts[opcode]
     if (count === undefined || offset + count * 4 > bytes.length) return
@@ -23,8 +40,19 @@ export function decodeCommands(bytes: Uint8Array): string | undefined {
     }
     if (opcode === 1) started = true
     if (started) commands.push(names[opcode] + values.join(" "))
+    records.push({
+      offset: start,
+      byteLength: offset - start,
+      opcode,
+      verb: names[opcode],
+      values,
+    })
   }
-  return commands.join(" ")
+  return { path: commands.join(" "), commands: records }
+}
+
+export function decodeCommands(bytes: Uint8Array): string | undefined {
+  return inspectCommands(bytes)?.path
 }
 
 export const identity: Matrix = {
@@ -122,9 +150,41 @@ export function primitivePath(node: NodeChange): string {
  * end, tangent); then regions containing lists of segment indices.
  * Cached paths remain preferable: they already include corner rounding/strokes.
  */
-export function decodeVectorNetwork(
+export interface NetworkVertex {
+  offset: number
+  style: number
+  x: number
+  y: number
+}
+
+export interface NetworkSegment {
+  offset: number
+  style: number
+  start: number
+  end: number
+  tx: number
+  ty: number
+  ex: number
+  ey: number
+}
+
+export interface NetworkRegion {
+  offset: number
+  flags: number
+  loops: { offset: number; segments: number[] }[]
+}
+
+export interface DecodedVectorNetwork {
+  fill: string
+  stroke: string
+  vertices: NetworkVertex[]
+  segments: NetworkSegment[]
+  regions: NetworkRegion[]
+}
+
+export function inspectVectorNetwork(
   bytes: Uint8Array
-): { fill: string; stroke: string } | undefined {
+): DecodedVectorNetwork | undefined {
   const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
   let offset = 0
   const u32 = () => {
@@ -146,11 +206,13 @@ export function decodeVectorNetwork(
       regionCount = u32()
     if (12 + vertexCount * 12 + segmentCount * 28 > bytes.length) return
     const vertices = Array.from({ length: vertexCount }, () => {
-      u32()
-      return { x: f32(), y: f32() }
+      const start = offset
+      const style = u32()
+      return { offset: start, style, x: f32(), y: f32() }
     })
     const segments = Array.from({ length: segmentCount }, () => {
-      u32()
+      const recordOffset = offset
+      const style = u32()
       const start = u32(),
         tx = f32(),
         ty = f32(),
@@ -159,7 +221,7 @@ export function decodeVectorNetwork(
         ey = f32()
       if (start >= vertexCount || end >= vertexCount)
         throw new Error("Invalid vertex")
-      return { start, end, tx, ty, ex, ey }
+      return { offset: recordOffset, style, start, end, tx, ty, ex, ey }
     })
     function contour(indices: number[]) {
       const remaining = new Set(indices)
@@ -213,25 +275,39 @@ export function decodeVectorNetwork(
       return commands.join(" ")
     }
     const fills: string[] = []
+    const regions: NetworkRegion[] = []
     if (regionCount > bytes.length / 8) return
     for (let i = 0; i < regionCount; i++) {
-      u32() // region style/winding flags; even-odd fallback preserves holes
+      const region: NetworkRegion = { offset, flags: u32(), loops: [] }
       const loops = u32()
       if (loops > bytes.length / 4) return
       for (let j = 0; j < loops; j++) {
+        const loopOffset = offset
         const count = u32()
         if (count > (bytes.length - offset) / 4) return
         const indices = Array.from({ length: count }, u32)
+        region.loops.push({ offset: loopOffset, segments: indices })
         fills.push(contour(indices))
       }
+      regions.push(region)
     }
     if (offset !== bytes.length) return
     const stroke = contour(segments.map((_, i) => i))
     return {
       fill: fills.length ? fills.join(" ") : stroke,
       stroke,
+      vertices,
+      segments,
+      regions,
     }
   } catch {
     return
   }
+}
+
+export function decodeVectorNetwork(
+  bytes: Uint8Array
+): { fill: string; stroke: string } | undefined {
+  const network = inspectVectorNetwork(bytes)
+  if (network) return { fill: network.fill, stroke: network.stroke }
 }

--- a/packages/fig-renderer/src/index.ts
+++ b/packages/fig-renderer/src/index.ts
@@ -1,2 +1,4 @@
 export { FigmaRenderer } from "./figma-renderer"
 export type { FigmaRendererProps } from "./figma-renderer"
+export { BlobInspector } from "./blob-inspector"
+export type { BlobInspectorProps } from "./blob-inspector"

--- a/packages/fig-renderer/tests/scene.test.ts
+++ b/packages/fig-renderer/tests/scene.test.ts
@@ -5,6 +5,8 @@ import type { NodeChange } from "fig-kiwi/schema-defs"
 import {
   decodeCommands,
   decodeVectorNetwork,
+  inspectCommands,
+  inspectVectorNetwork,
   identity,
   inverse,
   multiply,
@@ -73,6 +75,22 @@ describe("stored geometry", () => {
   test("handles byte views with a nonzero offset", () => {
     const wrapped = new Uint8Array([255, ...commands([1, 2, 3]), 255])
     expect(decodeCommands(wrapped.subarray(1, -1))).toBe("M2 3")
+  })
+  test("preserves byte offsets and leading close records for inspection", () => {
+    const bytes = commands([0], [1, 1.25, -2.5], [4, 1, 2, 3, 4, 5, 6], [0])
+    const wrapped = new Uint8Array([255, ...bytes, 255])
+    const decoded = inspectCommands(wrapped.subarray(1, -1))!
+    expect(decoded.path).toBe(decodeCommands(bytes)!)
+    expect(
+      decoded.commands.map((c) => [c.offset, c.byteLength, c.verb])
+    ).toEqual([
+      [0, 1, "Z"],
+      [1, 9, "M"],
+      [10, 25, "C"],
+      [35, 1, "Z"],
+    ])
+    expect(decoded.commands[1].values).toEqual([1.25, -2.5])
+    expect(inspectCommands(bytes.subarray(0, 34))).toBeUndefined()
   })
   test("decodes every cached path in the repository's exported circle fixture", () => {
     const file = readFigFile(
@@ -153,6 +171,31 @@ describe("stored geometry", () => {
     expect(decodeVectorNetwork(bytes)?.fill).toBe(
       "M0 0 C10 20 90 20 100 0 L0 100 L0 0 Z"
     )
+    // Preserve uninterpreted style words and exact record locations.
+    view.setUint32(12, 0x10203040, true)
+    view.setUint32(48, 9, true)
+    const wrapped = new Uint8Array([255, ...bytes, 255])
+    const inspected = inspectVectorNetwork(wrapped.subarray(1, -1))!
+    expect(inspected.vertices[0]).toEqual({
+      offset: 12,
+      style: 0x10203040,
+      x: 0,
+      y: 0,
+    })
+    expect(inspected.segments[0]).toEqual({
+      offset: 48,
+      style: 9,
+      start: 0,
+      end: 1,
+      tx: 10,
+      ty: 20,
+      ex: -10,
+      ey: 20,
+    })
+    expect(inspected.regions).toEqual([
+      { offset: 132, flags: 1, loops: [{ offset: 140, segments: [0, 2, 1] }] },
+    ])
+    expect(inspectVectorNetwork(new Uint8Array([...bytes, 0]))).toBeUndefined()
     expect(decodeVectorNetwork(bytes.slice(0, -1))).toBeUndefined()
     view.setUint32(12 + 3 * 12 + 4, 99, true)
     expect(decodeVectorNetwork(bytes)).toBeUndefined()


### PR DESCRIPTION
## Changes

Replaces hexadecimal blob dumps with a regular grid matching the image gallery: equal card sizes, square previews, and uniform gaps. Path / Network / Glyph appears inside each preview. Cards show up to three node IDs with reference arrows; clicking a preview opens the shared image lightbox with every reference, decoded records, and bytes using the app’s existing hex view. The sidebar shows the blob count.

The renderer package owns decoding and geometry previews; the app supplies its lightbox and byte view. Decoding is deferred until previews approach the viewport. Records retain byte offsets and uninterpreted style/flag values. Generated SVG strings are not presented as file contents. UI text uses 14px; code and binary values use 12px.

## Validation

`bun run check`, renderer build, and web production build passed. Browser checks verified equal grid heights, capped IDs, all 13 references for a shared glyph, modal geometry fitting, raw bytes, Escape dismissal, focus return, and an unchanged grid underneath the lightbox. Added decoder checks cover byte offsets, leading Close commands, byte views, raw style/flags, and malformed input.

## Screenshots

![Glyph lightbox with full reference list and decoded records](https://raw.githubusercontent.com/darknoon/figma-format-parse/2f389ccec4cda6be752e6314db6c505f5aca7272/screenshots/blob-lightbox.jpg)

## Stack

Depends on #3; review against `codex/fig-renderer`. Merge order: #3 → #4 → #5.
